### PR TITLE
Dear Marwan Nour, I fixed one error in logistic_ckks and changed the code to SEAL 3.6.

### DIFF
--- a/helper.h
+++ b/helper.h
@@ -19,10 +19,10 @@ void print_parameters(shared_ptr<SEALContext> context)
     string scheme_name;
     switch (context_data.parms().scheme())
     {
-    case scheme_type::BFV:
+    case scheme_type::bfv:
         scheme_name = "BFV";
         break;
-    case scheme_type::CKKS:
+    case scheme_type::ckks:
         scheme_name = "CKKS";
         break;
     default:
@@ -44,7 +44,7 @@ void print_parameters(shared_ptr<SEALContext> context)
     cout << coeff_modulus.back().bit_count();
     cout << ") bits" << endl;
 
-    if (context_data.parms().scheme() == scheme_type::BFV)
+    if (context_data.parms().scheme() == scheme_type::bfv)
     {
         cout << "|   plain_modulus: " << context_data.parms().plain_modulus().value() << endl;
     }
@@ -236,7 +236,7 @@ Ciphertext Linear_Transform_Cipher(Ciphertext ct, vector<Ciphertext> U_diagonals
 // Linear Transformation function between plaintext  matrix and ciphertext vector
 Ciphertext Linear_Transform_Plain(Ciphertext ct, vector<Plaintext> U_diagonals, GaloisKeys gal_keys, EncryptionParameters params)
 {
-    auto context = SEALContext::Create(params);
+    SEALContext context(params);
     Evaluator evaluator(context);
 
     // Fill ct with duplicate


### PR DESCRIPTION
Dear Marwan Nour,

(1) I changed your code to use SEAL 3.6;

(2) I fixed the error "ERROR HERE: CIPHERTEXT IS TRANSPARENT" in line 334; just rewrite line 329, "ckks_encoder.encode(N, N_pt);" to "ckks_encoder.encode(N, scale, N_pt);";

(3) I have a problem to discuss with you, I still don't know how to solve it. 
You set iters=10 in your code, but in the part of params setting, 
 "params.set_coeff_modulus(CoeffModulus::Create(16384, {60, 40, 40, 40, 40, 40, 40, 40, 60}));".
 Obviously, there're just 9 primes. 
Each sequential call to `rescale_to_next_inplace` removes one prime from the parameters, so clearly you won't be able to do logistic regression 10 iters when you have only 9 primes (8 data primes).
If you run it, you will meet error "scale out of bounds".
But if you changed 16384 to 32768 or larger number, the code will cost a large amout of time and resources.
Recently, I'm researching in using CKKS in AI, and I met the same problem.
Do you know how to deal with the problem "scale out of bounds", for example, run your code 10 iters successfully?
